### PR TITLE
coredns: dev image from image-rbac-proxy.apps.stone-prd-rh01.pg1f.p1.…

### DIFF
--- a/coredns/manifests/dev/manifests.yaml
+++ b/coredns/manifests/dev/manifests.yaml
@@ -160,7 +160,7 @@ spec:
         env:
         - name: WATCH_NAMESPACES
           value: ""
-        image: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-3-coredns:v1.3.0
+        image: image-rbac-proxy.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/redhat-user-workloads/api-management-tenant/rhcl-1-3-coredns@sha256:9ab83ba35e0b74569b76e689c790213515607b8a999e03a5461f9a5783c7cfc1
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5

--- a/coredns/overlays/dev/kustomization.yaml
+++ b/coredns/overlays/dev/kustomization.yaml
@@ -7,5 +7,5 @@ resources:
 # Dev: uses images from quay.io/redhat-user-workloads
 images:
   - name: quay.io/kuadrant/coredns-kuadrant
-    newName: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-3-coredns
-    newTag: v1.3.0
+    newName: image-rbac-proxy.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/redhat-user-workloads/api-management-tenant/rhcl-1-3-coredns
+    digest: sha256:9ab83ba35e0b74569b76e689c790213515607b8a999e03a5461f9a5783c7cfc1


### PR DESCRIPTION
…openshiftapps.com

latest build from 8dffee4
https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/api-management-tenant/applications/rhcl-1-3-coredns/commit/8dffee4fbe1c7313bdce0f168458b910ffcdbb97

Got this working on OCP 4.20. Steps followed:

* Extract the image (only `coredns` folder
* apply the manifests
* Add pull secret to the `default` serviceaccount (assigned to the coredns pod)
```
oc project kuadrant-coredns
oc create secret docker-registry konflux-dev-env-pull-secret \
    --docker-server=image-rbac-proxy.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com \
    --docker-username=<USERNAME> \
    --docker-password=<PASSWORD_FROM_KONFLUX> \
    -n kuadrant-coredns
```

```
# You must use the --for=pull flag. This tells OpenShift to use this secret specifically for pulling images, rather than mounting it as a volume.
oc secrets link default konflux-dev-env-pull-secret --for=pull
```

Now, the pod is up and running: logs
```
❯ k logs deployment/kuadrant-coredns 
2026/02/11 11:18:18 [INFO] plugin version: , gitSha: 
2026/02/11 11:18:18 [INFO] go version: go1.25.5 (Red Hat 1.25.5-2.el9_7)
2026/02/11 11:18:18 [INFO] arch: amd64
maxprocs: Updating GOMAXPROCS=1: using minimum allowed GOMAXPROCS
.:53
CoreDNS-1.13.1+kuadrant-
linux/amd64, go1.25.5 (Red Hat 1.25.5-2.el9_7),
```
